### PR TITLE
Adding missing CSRF headers to 2048 widgets

### DIFF
--- a/training-collection/2048-widget-highscores/js/highscores.js
+++ b/training-collection/2048-widget-highscores/js/highscores.js
@@ -13,11 +13,15 @@ training.highscores = (function ($) {
             var $widget = $(widget.body);
             var $list = $widget.find(".players");
 
+            var headers = {};
+            headers[b$.utils.xsrf.getXSRFRequestHeaderName()] = b$.utils.xsrf.getXSRFCookie();
+
             $.ajax({
                 url: "/portalserver/services/rest/player/players/highscore",
                 dataType: "json",
                 type: "GET",
                 contentType: "application/json; charset=utf-8",
+                headers: headers,
                 success: function (data) {
                     $.each(data.players, function(index, player) {
                         $list.append('<li data-player="' + player.username + '"><span class="player-name">' + player.fullname + '</span><span class="player-score">' + player.highScore + '</span>');

--- a/training-collection/2048-widget-login/js/login.js
+++ b/training-collection/2048-widget-login/js/login.js
@@ -16,16 +16,18 @@ training.login = (function ($) {
 
             $form.submit(function (event) {
                 event.preventDefault();
-console.log('hello');
+
+                var headers = {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/x-www-form-urlencoded;'
+                };
+                headers[b$.utils.xsrf.getXSRFRequestHeaderName()] = b$.utils.xsrf.getXSRFCookie();
 
                 var xhr = $.ajax({
                     type: "POST",
                     url: "/portalserver/j_spring_security_check",
                     data: $form.serialize(),
-                    headers: {
-                        'Accept': 'application/json',
-                        'Content-Type': 'application/x-www-form-urlencoded;'
-                    }
+                    headers: headers
                 });
 
                 xhr.success(function (response) {

--- a/training-collection/2048-widget-players/js/players.js
+++ b/training-collection/2048-widget-players/js/players.js
@@ -13,11 +13,15 @@ training.players = (function ($) {
             var $widget = $(widget.body);
             var $list = $widget.find(".players");
 
+            var headers = {};
+            headers[b$.utils.xsrf.getXSRFRequestHeaderName()] = b$.utils.xsrf.getXSRFCookie();
+
             $.ajax({
                 url: "/portalserver/services/rest/player/list?sort=username",
                 dataType: "json",
                 type: "GET",
                 contentType: "application/json; charset=utf-8",
+                headers: headers,
                 success: function (data) {
                     $.each(data.players, function(index, player) {
                         $list.append('<li data-player="' + player.username + '"><span class="player-name">' + player.fullname + '</span><span class="player-score">' + player.highScore + '</span>');

--- a/training-collection/2048-widget-register/js/register.js
+++ b/training-collection/2048-widget-register/js/register.js
@@ -21,10 +21,14 @@ training.register = (function ($) {
                     "birthDay": $("#reg_birthDay").val()
                 };
 
+                var headers = {};
+                headers[b$.utils.xsrf.getXSRFRequestHeaderName()] = b$.utils.xsrf.getXSRFCookie();
+
                 var xhr = $.ajax({
                     type: $form.attr("method"),
                     url: $form.attr("action"),
                     data: JSON.stringify(data),
+                    headers: headers,
                     contentType:"application/json; charset=utf-8",
                     dataType: "json"
                 });


### PR DESCRIPTION
Adding CSRF headers to the Ajax requests for the 2048 widgets so it works with CXP 5.6.2.