### PR TITLE
Update pom.xml

### DIFF
--- a/enterprise-integration-module/pom.xml
+++ b/enterprise-integration-module/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.backbase.portal.integration</groupId>
             <artifactId>integration-shared</artifactId>
-            <version>${portal.integration.version}</version>
+            <version>${portal.server.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
${portal.integration.version} is not there anymore in the archetype. Exercises must be tested with every version of the archetype to check that everything keeps working/